### PR TITLE
Add an option to disable the default keymaps

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,13 @@ Append the appropriate closing tag at the cursor with:
 - Normal-mode: <kbd>g/</kbd>
 
 
+### Settings
+
+* `g:tag_closer_enable_default_keymaps` (bool, default: `1`)
+
+  Set to `0` to disable the default keymaps. In this case, you will need to create your own keymaps.
+
+
 ### Intellectual property
 
 Copyright 2022 Andrew Stewart.  Released under the MIT licence.

--- a/doc/tag_closer.txt
+++ b/doc/tag_closer.txt
@@ -26,4 +26,11 @@ Insert    <C-g>/
 Normal    g/
 
 
+SETTINGS                                *tag_closer-settings*
+
+g:tag_closer_enable_default_keymaps     (bool, default: 1)
+  Set to 0 to disable the default keymaps. In this case, you will need to
+  create your own keymaps.
+
+
   vim:tw=78:et:ft=help:norl:

--- a/plugin/tag_closer.vim
+++ b/plugin/tag_closer.vim
@@ -4,6 +4,11 @@ endif
 let g:loaded_tag_closer = 1
 
 
+if !exists('g:tag_closer_enable_default_keymaps')
+  " If true, set up the default keymaps.
+  let g:tag_closer_enable_default_keymaps = 1
+endif
+
 let s:void_elements = ['area', 'area', 'base', 'br', 'col', 'embed',
       \ 'hr', 'img', 'input', 'link', 'meta', 'source', 'track', 'wbr']
 
@@ -66,5 +71,7 @@ endfunction
 
 noremap <Plug>(CloseTag) :call CloseTag()<CR>
 
-nmap g/ <Plug>(CloseTag)
-imap <C-G>/ <C-O><Plug>(CloseTag)
+if g:tag_closer_enable_default_keymaps
+  nmap g/ <Plug>(CloseTag)
+  imap <C-G>/ <C-O><Plug>(CloseTag)
+endif


### PR DESCRIPTION
Thanks for the plugin! Finally, there is one that works for me :). I have an improvement suggestion for you.

In my case, I wanted to create my own keymaps. However, there was no option to prevent the default ones from being created, so I had to unmap them first. This PR adds a setting to disable the default keymaps, which simplifies the process.

Feel free to let me know if you would prefer different naming, formatting, etc.